### PR TITLE
Remove deprecated io/ioutil from local-list.go

### DIFF
--- a/command/local-list.go
+++ b/command/local-list.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"flag"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,7 +45,7 @@ func (c *localListCommand) Run(args []string) int {
 		c.ui.Error(err.Error())
 		return 1
 	}
-	files, _ := ioutil.ReadDir(tfDataPATH)
+	files, _ := os.ReadDir(tfDataPATH)
 	for _, f := range files {
 		if f.IsDir() && strings.HasPrefix(f.Name(), filter) {
 			c.ui.Output(f.Name())


### PR DESCRIPTION
Fix for:
```
$ golangci-lint run
local-list.go:5:2: SA1019: "io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package [io] or package [os], and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
        "io/ioutil"
        ^
```